### PR TITLE
Add protection to lists and improve log out performance

### DIFF
--- a/src/components/MenuNavBar/index.js
+++ b/src/components/MenuNavBar/index.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import { Menu, MenuItem } from "./styles";
+import { useDispatch } from 'react-redux';
+import { logUserOut } from '../../store/usersReducer'
+import { clearServices } from '../../store/servicesReducer'
+
 
 
 export default function MenuNavBar() {
 
+  const dispatch = useDispatch();
+
+  function logOut() {
+    localStorage.clear();
+    dispatch(logUserOut());
+    dispatch(clearServices());
+  };
+  
   return (
     <Menu>
       <MenuItem to="/userinfo">Ver perfil</MenuItem>
-      <MenuItem to="/" onClick={() =>localStorage.clear()}>Cerrar sesión</MenuItem>
+      <MenuItem to="/" onClick={() => logOut()}>Cerrar sesión</MenuItem>
     </Menu>
   );  
 };

--- a/src/pages/ListMotorcycle/index.js
+++ b/src/pages/ListMotorcycle/index.js
@@ -10,18 +10,19 @@ import { getTows, deleteErrorTows } from '../../store/towsReducer';
 
 function ListMotorcycle () {
   const dispatch = useDispatch();
-  const { loading, tows, userID, errorTows } = useSelector(({ towsReducer }) => ({
+  const { loading, tows, userID, errorTows, userType } = useSelector(({ towsReducer, usersReducer }) => ({
     loading: towsReducer.loading,
     tows: towsReducer.tows,
     userID: towsReducer.userID,
+    userType: usersReducer.userType,
     errorTows: towsReducer.errorTows,
   }));
+
+  let history = useHistory();
 
   useEffect(() => {
     dispatch(getTows());
   }, []);
-  
-  let history = useHistory();
 
   if (loading) return <p>loading ...</p>;
 
@@ -36,6 +37,9 @@ function ListMotorcycle () {
     });
     dispatch(deleteErrorTows());
   }
+
+  if(userType === 'supplier') history.push('/listtow');
+
   return (
     <section>
       <NavBar userID={userID} />

--- a/src/pages/ListTow/index.js
+++ b/src/pages/ListTow/index.js
@@ -11,10 +11,9 @@ import axios from 'axios';
 
 function ListTow() {
   const dispatch = useDispatch();
-  const { loading, services, userID, errorServices, userFront } = useSelector(
+  const { loading, errorServices, userFront, userType } = useSelector(
     ({ servicesReducer, usersReducer }) => ({
-      services: servicesReducer.services,
-      userID: servicesReducer.userID,
+      userType: usersReducer.userType,
       errorServices: servicesReducer.errorServices,
       userFront: usersReducer.userFront,
     })
@@ -75,6 +74,8 @@ function ListTow() {
 
     dispatch(deleteError());
   }
+
+  if(userType === 'client') history.push('/listmotorcycle');
 
   return (
     <section>

--- a/src/store/servicesReducer.js
+++ b/src/store/servicesReducer.js
@@ -7,6 +7,7 @@ const SERVICES_SUCCESS = 'SERVICES_SUCCESS';
 const SERVICES_UPDATED = 'SERVICES_UPDATED';
 const SERVICES_FINISHED = 'SERVICES_FINISHED';
 const SERVICES_DELETE_ERROR = 'SERVICES_DELETE_ERROR';
+const SERVICES_CLEAR = 'SERVICES_CLEAR';
 
 export function getServices(query='') {
   return async function (dispatch) {
@@ -28,9 +29,9 @@ export function getServices(query='') {
       dispatch({ type: SERVICES_ERROR, payload: error });
     } finally {
       dispatch({ type: SERVICES_FINISHED});
-    }
+    };
   };
-}
+};
 
 export function createService( initLoc, finalLoc, date, bikeID, towID ) {
   return async function (dispatch) {
@@ -59,9 +60,9 @@ export function createService( initLoc, finalLoc, date, bikeID, towID ) {
       dispatch({ type: SERVICES_ERROR, payload: error });
     } finally {
       dispatch({ type: SERVICES_FINISHED});
-    }
+    };
   };
-}
+};
 
 export function updateService ( serviceID, dataUpdate, updatedServiceIndex ) {
   return async function (dispatch) {
@@ -83,15 +84,21 @@ export function updateService ( serviceID, dataUpdate, updatedServiceIndex ) {
       dispatch({ type: SERVICES_ERROR, payload: error });
     } finally {
       dispatch({ type: SERVICES_FINISHED });
-    }
+    };
   };
-}
+};
 
 export function deleteError() {
   return {
     type: SERVICES_DELETE_ERROR,
-  }
-}
+  };
+};
+
+export function clearServices() {
+  return {
+    type: SERVICES_CLEAR,
+  };
+};
 
 const initialState = {
   loading: false,
@@ -133,7 +140,7 @@ export function servicesReducer(state = initialState, action) {
             service
           )
         }), 
-      }
+      };
     case SERVICES_FINISHED:
       return {
         ...state,
@@ -143,8 +150,15 @@ export function servicesReducer(state = initialState, action) {
       return {
         ...state,
         errorServices: null,
-      }
+      };
+    case SERVICES_CLEAR:
+      return {
+        loading: false,
+        services: [],
+        userID: '',
+        errorServices: null,
+      };
     default:
       return state;
-  }
-}
+  };
+};

--- a/src/store/usersReducer.js
+++ b/src/store/usersReducer.js
@@ -3,7 +3,8 @@ import axios from 'axios'
 const USERS_LOADING = 'USERS_LOADING';
 const USERS_SUCCESS = 'USERS_SUCCESS';
 const USERS_ERROR = 'USERS_ERROR';
-const USERS_DELETE_ERROR = 'USERS_DELETE_ERROR'
+const USERS_DELETE_ERROR = 'USERS_DELETE_ERROR';
+const USERS_LOG_OUT = 'USERS_LOG_OUT';
 
 export function registerUser(firstName, lastName, email, phoneNum, password, userTypeForm) {
   return async function(dispatch) {
@@ -24,9 +25,9 @@ export function registerUser(firstName, lastName, email, phoneNum, password, use
       dispatch({ type: USERS_SUCCESS, payload: {userFront, userType: userTypeForm} })
     } catch(error) {
       dispatch({ type: USERS_ERROR, payload: error })
-    }
-  }
-}
+    };
+  };
+};
 
 export function getLoggedUser() {
   return async function(dispatch) {
@@ -46,9 +47,9 @@ export function getLoggedUser() {
       dispatch({ type: USERS_SUCCESS, payload: {userFront, userType} })
     } catch(error) {
       dispatch({ type: USERS_ERROR, payload: error })
-    }
-  }
-}
+    };
+  };
+};
 
 export function loginUser( email, password, history) {
   return async function(dispatch) {
@@ -75,15 +76,21 @@ export function loginUser( email, password, history) {
       dispatch({ type: USERS_SUCCESS, payload: {userFront, userType } })
     } catch(error) {
       dispatch({ type: USERS_ERROR, payload: error })
-    }
-  }
-}
+    };
+  };
+};
+
+export function logUserOut(){
+  return {
+    type: USERS_LOG_OUT,
+  };
+};
 
 export function deleteError(){
   return {
     type: USERS_DELETE_ERROR,
-  }
-}
+  };
+};
 
 const initialState = {
   userFront: {},
@@ -110,14 +117,21 @@ export function usersReducer(state = initialState, action) {
         ...state,
         loading: false,
         errorUsers: action.payload,
-      }
+      };
     case USERS_DELETE_ERROR:
       return {
         ...state,
         loading: false,
         errorUsers: null,
-      }
+      };
+    case USERS_LOG_OUT:
+      return {
+        userFront: {},
+        userType: '',
+        loading: false,
+        errorUsers: null,
+      };
     default:
       return state;  
-  }
-}
+  };
+};


### PR DESCRIPTION
- Logging out now clears the redux state to prevent issues when trying to log back in.

- Users are now unable to access a list page if it does not correspond to their userType. If they do try to access it by manually typing the URL in, they are redirected to the expected list page.